### PR TITLE
Add Cross-Platform Support to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ docs: ## Build and serve the documentation
 
 .PHONY: help
 help:
-	@python -c "import re; \
-	[print(f'{m[0]:<20} {m[1]}') for m in re.findall(r'^([a-zA-Z_-]+):.*?## (.*)$$', open('$(MAKEFILE_LIST)').read(), re.M)]"
+	@uv run python -c "import re; \
+	[print(f'\033[36m{m[0]:<20}\033[0m {m[1]}') for m in re.findall(r'^([a-zA-Z_-]+):.*?## (.*)$$', open('$(MAKEFILE_LIST)').read(), re.M)]"
 
 .DEFAULT_GOAL := help

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,8 @@ build: clean-build ## Build wheel file
 
 .PHONY: clean-build
 clean-build: ## clean build artifacts
-	@rm -rf dist
+	@echo "[-] Removing build artifacts"
+	@python -c "import shutil; import os; shutil.rmtree('dist', ignore_errors=True) if os.path.exists('dist') else None"
 
 .PHONY: publish
 publish: ## Publish a release to PyPI.
@@ -78,6 +79,7 @@ docs: ## Build and serve the documentation
 
 .PHONY: help
 help:
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+	@python -c "import re; \
+	[print(f'{m[0]:<20} {m[1]}') for m in re.findall(r'^([a-zA-Z_-]+):.*?## (.*)$$', open('$(MAKEFILE_LIST)').read(), re.M)]"
 
 .DEFAULT_GOAL := help

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ build: clean-build ## Build wheel file
 .PHONY: clean-build
 clean-build: ## clean build artifacts
 	@echo "🚀 Removing build artifacts"
-	@python -c "import shutil; import os; shutil.rmtree('dist') if os.path.exists('dist') else None"
+	@uv run python -c "import shutil; import os; shutil.rmtree('dist') if os.path.exists('dist') else None"
 
 .PHONY: publish
 publish: ## Publish a release to PyPI.

--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,8 @@ build: clean-build ## Build wheel file
 
 .PHONY: clean-build
 clean-build: ## clean build artifacts
-	@echo "[-] Removing build artifacts"
-	@python -c "import shutil; import os; shutil.rmtree('dist', ignore_errors=True) if os.path.exists('dist') else None"
+	@echo "🚀 Removing build artifacts"
+	@python -c "import shutil; import os; shutil.rmtree('dist') if os.path.exists('dist') else None"
 
 .PHONY: publish
 publish: ## Publish a release to PyPI.

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ build: clean-build ## Build wheel file
 	@uvx --from build pyproject-build --installer uv
 
 .PHONY: clean-build
-clean-build: ## clean build artifacts
+clean-build: ## Clean build artifacts
 	@echo "🚀 Removing build artifacts"
 	@uv run python -c "import shutil; import os; shutil.rmtree('dist') if os.path.exists('dist') else None"
 


### PR DESCRIPTION
_Thanks for setting up this project and making it publicly available!_

**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR. (Not applicable)
- [ ] If you've fixed a bug or added code that should be tested, add tests! (Not applicable)
- [ ] Documentation in `docs` is updated (Not applicable)

**Description of changes**

The PR refactors the Makefile to add support for Windows environments, while maintaining compatibility for Unix-based systems (tested on Ubuntu 22.04) as well.

***Changes:***
- `clean-build`:
  - Replaced `rm -rf dist` with `shutil.rmtree('dist')` which allows for Windows compatibility
  - Added a log message: `"🚀 Removing build artifacts"`
- `help`:
  - Replaced `grep` and `awk` with a Python-based print that utilizes `re`
  - Maintained the colors and format


**Testing**

Verfied `make help`, `make build` and `make clean-build` on the following platforms:
- Windows 11 with Python 3.12
- Ubuntu 22.04 with Python 3.12
