### PR TITLE
Fix action errors when codecov is "n" and replaced hardcoded names with placeholders

### DIFF
--- a/docs/features/codecov.md
+++ b/docs/features/codecov.md
@@ -25,3 +25,5 @@ coverage:
 ignore:
   - "foo/bar.py"
 ```
+
+If `codecov` is set to `"n"`, `pytest-cov` is not added to the development dependencies and the github actions won't produce a coverage report.

--- a/{{cookiecutter.project_name}}/.github/workflows/main.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
           python-version: {% raw %}${{ matrix.python-version }}{% endraw %}
 
       - name: Run tests
-        run: uv run python -m pytest tests --cov --cov-config=pyproject.toml --cov-report=xml
+        run: uv run python -m pytest tests {% if cookiecutter.codecov == "y" %}--cov --cov-config=pyproject.toml --cov-report=xml{%- endif %}
 
       - name: Check typing
         run: uv run mypy

--- a/{{cookiecutter.project_name}}/CONTRIBUTING.md
+++ b/{{cookiecutter.project_name}}/CONTRIBUTING.md
@@ -29,7 +29,7 @@ Anything tagged with "enhancement" and "help wanted" is open to whoever wants to
 
 ## Write Documentation
 
-Cookiecutter PyPackage could always use more documentation, whether as part of the official docs, in docstrings, or even on the web in blog posts, articles, and such.
+{{cookiecutter.project_name}} could always use more documentation, whether as part of the official docs, in docstrings, or even on the web in blog posts, articles, and such.
 
 ## Submit Feedback
 

--- a/{{cookiecutter.project_name}}/mkdocs.yml
+++ b/{{cookiecutter.project_name}}/mkdocs.yml
@@ -5,7 +5,7 @@ site_description: {{cookiecutter.project_description}}
 site_author: {{cookiecutter.author}}
 edit_uri: edit/main/docs/
 repo_name: {{cookiecutter.author_github_handle}}/{{cookiecutter.project_name}}
-copyright: Maintained by <a href="https://{{cookiecutter.author_github_handle}}.com">Florian</a>.
+copyright: Maintained by <a href="https://{{cookiecutter.author_github_handle}}.com">{{cookiecutter.author_github_handle}}</a>.
 
 nav:
   - Home: index.md


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests! 
Not sure how to do that as it already throws  an error on github actions when creating a repo without codecov but that kind of testing is not part of the current framework and would require something like act to test the actions.
Alternatively one could use a script that extracts the run command. But I am not sure if that is very useful in the end as it can't take all previous steps into account.
- [x] Documentation in `docs` is updated

**Description of changes**

The Contributing.md contained a reference to Cookiecutter PyPackage which is replaced with an appropriate placeholder to avoid that adapting this section is overlooked by someone.
Also the hard-coded name of the maintainer in mkdocs.yml was replaced with a placeholder.

The "Run tests" action step in main.yml is changed such that it runs successfully also without codecov dependencies installed.

Docs are rewritten to make clear that no coverage report is created without codecov set to "y"
