### PR TITLE
Add option for `src` layout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@
 bake: ## bake without inputs and overwrite if exists.
 	@uv run cookiecutter --no-input . --overwrite-if-exists
 
+.PHONY: bake-src
+bake-src: ## bake without inputs and overwrite if exists.
+	@uv run cookiecutter --no-input . --overwrite-if-exists layout="src"
+
 .PHONY: bake-with-inputs
 bake-with-inputs: ## bake with inputs and overwrite if exists.
 	@uv run cookiecutter . --overwrite-if-exists
@@ -10,6 +14,7 @@ bake-with-inputs: ## bake with inputs and overwrite if exists.
 bake-and-test-deploy: ## For quick publishing to cookiecutter-uv-example to test GH Actions
 	@rm -rf cookiecutter-uv-example || true
 	@uv run cookiecutter --no-input . --overwrite-if-exists \
+		layout="src" \
 		author="Florian Maas" \
 		email="fpgmaas@gmail.com" \
 		github_author_handle=fpgmaas \
@@ -42,7 +47,7 @@ check: ## Run code quality tools.
 	@echo "🚀 Static type checking: Running mypy"
 	@uv run mypy
 	@echo "🚀 Checking for obsolete dependencies: Running deptry"
-	@uv run deptry .
+	@uv run deptry {% if cookiecutter.layout == "src" %}"src"{% else %}.{% endif %}
 
 .PHONY: test
 test: ## Test the code with pytest.

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,6 @@ bake-with-inputs: ## bake with inputs and overwrite if exists.
 bake-and-test-deploy: ## For quick publishing to cookiecutter-uv-example to test GH Actions
 	@rm -rf cookiecutter-uv-example || true
 	@uv run cookiecutter --no-input . --overwrite-if-exists \
-		layout="src" \
 		author="Florian Maas" \
 		email="fpgmaas@gmail.com" \
 		github_author_handle=fpgmaas \

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 This is a modern Cookiecutter template that can be used to initiate a Python project with all the necessary tools for development, testing, and deployment. It supports the following features:
 
 - [uv](https://docs.astral.sh/uv/) for dependency management
+- Supports both [src and flat layout](https://packaging.python.org/en/latest/discussions/src-layout-vs-flat-layout/).
 - CI/CD with [GitHub Actions](https://github.com/features/actions)
 - Pre-commit hooks with [pre-commit](https://pre-commit.com/)
 - Code quality with [ruff](https://github.com/charliermarsh/ruff), [mypy](https://mypy.readthedocs.io/en/stable/), [deptry](https://github.com/fpgmaas/deptry/) and [prettier](https://prettier.io/)

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -5,6 +5,7 @@
     "project_name": "example-project",
     "project_slug": "{{cookiecutter.project_name|lower|replace('-', '_')}}",
     "project_description": "This is a template repository for Python projects that use uv for their dependency management.",
+    "layout": ["flat", "src"],
     "include_github_actions": ["y", "n"],
     "publish_to_pypi": ["y", "n"],
     "deptry": ["y", "n"],

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@
 This is a modern Cookiecutter template that can be used to initiate a Python project with all the necessary tools for development, testing, and deployment. It supports the following features:
 
 - [uv](https://docs.astral.sh/uv/) for dependency management
+- Supports both [src and flat layout](https://packaging.python.org/en/latest/discussions/src-layout-vs-flat-layout/).
 - CI/CD with [GitHub Actions](https://github.com/features/actions)
 - Pre-commit hooks with [pre-commit](https://pre-commit.com/)
 - Code quality with [ruff](https://github.com/charliermarsh/ruff), [mypy](https://mypy.readthedocs.io/en/stable/), [deptry](https://github.com/fpgmaas/deptry/) and [prettier](https://prettier.io/)

--- a/docs/prompt_arguments.md
+++ b/docs/prompt_arguments.md
@@ -35,6 +35,13 @@ from <project_slug> import foo
 
 A short description of your project.
 
+**layout**
+
+`"flat"` or `"src"`, defaults to `"flat"`.
+
+- `"flat"`: Places the Python module in the root directory.
+- `"src"`: Organizes the project by placing the Python module inside a `src` directory.
+
 **include_github_actions**
 
 `"y"` or `"n"`. Adds a `.github` directory with various actions and

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -19,6 +19,10 @@ def move_file(filepath: str, target: str) -> None:
     os.rename(os.path.join(PROJECT_DIRECTORY, filepath), os.path.join(PROJECT_DIRECTORY, target))
 
 
+def move_dir(src: str, target: str) -> None:
+    shutil.move(os.path.join(PROJECT_DIRECTORY, src), os.path.join(PROJECT_DIRECTORY, target))
+
+
 if __name__ == "__main__":
     if "{{cookiecutter.include_github_actions}}" != "y":
         remove_dir(".github")
@@ -82,3 +86,8 @@ if __name__ == "__main__":
         remove_file("LICENSE_BSD")
         remove_file("LICENSE_ISC")
         remove_file("LICENSE_APACHE")
+
+    if "{{cookiecutter.layout}}" == "src":
+        if os.path.isdir("src"):
+            remove_dir("src")
+        move_dir("{{cookiecutter.project_slug}}", os.path.join("src", "{{cookiecutter.project_slug}}"))

--- a/tests/test_cookiecutter.py
+++ b/tests/test_cookiecutter.py
@@ -33,6 +33,23 @@ def test_using_pytest(cookies, tmp_path):
             assert subprocess.check_call(shlex.split("uv run make test")) == 0
 
 
+def test_src_layout_using_pytest(cookies, tmp_path):
+    with run_within_dir(tmp_path):
+        result = cookies.bake(extra_context={"layout": "src"})
+
+        # Assert that project was created.
+        assert result.exit_code == 0
+        assert result.exception is None
+        assert result.project_path.name == "example-project"
+        assert result.project_path.is_dir()
+        assert is_valid_yaml(result.project_path / ".github" / "workflows" / "main.yml")
+
+        # Install the uv environment and run the tests.
+        with run_within_dir(str(result.project_path)):
+            assert subprocess.check_call(shlex.split("uv sync")) == 0
+            assert subprocess.check_call(shlex.split("uv run make test")) == 0
+
+
 def test_devcontainer(cookies, tmp_path):
     """Test that the devcontainer files are created when devcontainer=y"""
     with run_within_dir(tmp_path):

--- a/{{cookiecutter.project_name}}/mkdocs.yml
+++ b/{{cookiecutter.project_name}}/mkdocs.yml
@@ -15,7 +15,13 @@ plugins:
   - mkdocstrings:
       handlers:
         python:
-          paths: [{{cookiecutter.project_slug}}]
+          paths: [
+            {%- if cookiecutter.layout == "src" -%}
+            "src/{{cookiecutter.project_slug}}"
+            {%- else -%}
+            "{{cookiecutter.project_slug}}"
+            {%- endif -%}
+            ]
 theme:
   name: material
   feature:

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -41,11 +41,19 @@ dev = [
 requires = ["setuptools >= 61.0"]
 build-backend = "setuptools.build_meta"
 
+{% if cookiecutter.layout == "flat" -%}
 [tool.setuptools]
 py-modules = ["{{cookiecutter.project_slug}}"]
+{%- endif %}
 
 [tool.mypy]
-files = ["{{cookiecutter.project_slug}}"]
+files = [
+    {%- if cookiecutter.layout == "src" -%}
+    "src"
+    {%- else -%}
+    "{{cookiecutter.project_slug}}"
+    {%- endif -%}
+]
 disallow_untyped_defs = true
 disallow_any_unimported = true
 no_implicit_optional = true
@@ -114,5 +122,11 @@ skip_empty = true
 
 [tool.coverage.run]
 branch = true
-source = ["{{cookiecutter.project_slug}}"]
+source = [
+    {%- if cookiecutter.layout == "src" -%}
+    "src"
+    {%- else -%}
+    "{{cookiecutter.project_slug}}"
+    {%- endif -%}
+]
 {% endif %}


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Documentation in `docs` is updated

**Description of changes**

Add a new argument; **layout**, which has values "flat"` or `"src"` and defaults to `"flat"`.

- `"flat"`: Places the Python module in the root directory.
- `"src"`: Organizes the project by placing the Python module inside a `src` directory.

Currently, we only test that the `make test` commands functions as expected in the unit tests. Ideally, we'd also test if the documentation functions as expected, and if tools like `mypy` and `deptry` work as expected. I think it would be good to overhaul the testing a bit, but I'll leave that for a follow-up PR.