### PR TITLE
fix dev container

### DIFF
--- a/{{cookiecutter.project_name}}/.devcontainer/postCreateCommand.sh
+++ b/{{cookiecutter.project_name}}/.devcontainer/postCreateCommand.sh
@@ -2,7 +2,6 @@
 
 # Install uv
 curl -LsSf https://astral.sh/uv/install.sh | sh
-source $HOME/.cargo/env
 
 # Install Dependencies
 uv sync


### PR DESCRIPTION
**PR Checklist**

- [ ] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated

**Description of changes**

Currently the dev container fails to start, since it tries to run `source $HOME/.cargo/env`, however that deos not exist since cargo is not installed. Cargo should not be needed in the dev container by default; removed the command.
