### PR TITLE
Remove prettier

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,0 @@
-[*]
-max_line_length = 120
-
-[*.json]
-indent_style = space
-indent_size = 4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,19 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: "v4.4.0"
+    rev: "v5.0.0"
     hooks:
       - id: check-case-conflict
       - id: check-merge-conflict
       - id: end-of-file-fixer
       - id: trailing-whitespace
+      - id: pretty-format-json
+        exclude: ^({{cookiecutter.project_name}}/\.devcontainer/devcontainer\.json|\.devcontainer/devcontainer\.json|{{cookiecutter.project_name}}/)$
+      - id: check-json
+        exclude: ^({{cookiecutter.project_name}}/\.devcontainer/devcontainer\.json|\.devcontainer/devcontainer\.json|{{cookiecutter.project_name}}/)$
+      - id: check-toml
+        exclude: ^{{cookiecutter.project_name}}/
+      - id: check-yaml
+        exclude: ^{{cookiecutter.project_name}}/
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: "v0.6.3"
@@ -15,10 +23,4 @@ repos:
         exclude: ^{{cookiecutter.project_name}}
       - id: ruff-format
         args: [--config=pyproject.toml]
-        exclude: ^{{cookiecutter.project_name}}
-
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v3.0.3"
-    hooks:
-      - id: prettier
         exclude: ^{{cookiecutter.project_name}}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,10 +6,11 @@ repos:
       - id: check-merge-conflict
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      - id: pretty-format-json
-        exclude: ^({{cookiecutter.project_name}}/\.devcontainer/devcontainer\.json|\.devcontainer/devcontainer\.json|{{cookiecutter.project_name}}/)$
       - id: check-json
         exclude: ^({{cookiecutter.project_name}}/\.devcontainer/devcontainer\.json|\.devcontainer/devcontainer\.json|{{cookiecutter.project_name}}/)$
+      - id: pretty-format-json
+        exclude: ^({{cookiecutter.project_name}}/\.devcontainer/devcontainer\.json|\.devcontainer/devcontainer\.json|{{cookiecutter.project_name}}/)$
+        args: [--autofix]
       - id: check-toml
         exclude: ^{{cookiecutter.project_name}}/
       - id: check-yaml

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This is a modern Cookiecutter template that can be used to initiate a Python pro
 - Supports both [src and flat layout](https://packaging.python.org/en/latest/discussions/src-layout-vs-flat-layout/).
 - CI/CD with [GitHub Actions](https://github.com/features/actions)
 - Pre-commit hooks with [pre-commit](https://pre-commit.com/)
-- Code quality with [ruff](https://github.com/charliermarsh/ruff), [mypy](https://mypy.readthedocs.io/en/stable/), [deptry](https://github.com/fpgmaas/deptry/) and [prettier](https://prettier.io/)
+- Code quality with [ruff](https://github.com/charliermarsh/ruff), [mypy](https://mypy.readthedocs.io/en/stable/) and [deptry](https://github.com/fpgmaas/deptry/).
 - Publishing to [PyPI](https://pypi.org) by creating a new release on GitHub
 - Testing and coverage with [pytest](https://docs.pytest.org/en/7.1.x/) and [codecov](https://about.codecov.io/)
 - Documentation with [MkDocs](https://www.mkdocs.org/)

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,24 +1,48 @@
 {
-    "author": "Florian Maas",
-    "email": "fpgmaas@gmail.com",
-    "author_github_handle": "fpgmaas",
-    "project_name": "example-project",
-    "project_slug": "{{cookiecutter.project_name|lower|replace('-', '_')}}",
-    "project_description": "This is a template repository for Python projects that use uv for their dependency management.",
-    "layout": ["flat", "src"],
-    "include_github_actions": ["y", "n"],
-    "publish_to_pypi": ["y", "n"],
-    "deptry": ["y", "n"],
-    "mkdocs": ["y", "n"],
-    "codecov": ["y", "n"],
-    "dockerfile": ["y", "n"],
-    "devcontainer": ["y", "n"],
-    "open_source_license": [
-        "MIT license",
-        "BSD license",
-        "ISC license",
-        "Apache Software License 2.0",
-        "GNU General Public License v3",
-        "Not open source"
-    ]
+  "author": "Florian Maas",
+  "author_github_handle": "fpgmaas",
+  "codecov": [
+    "y",
+    "n"
+  ],
+  "deptry": [
+    "y",
+    "n"
+  ],
+  "devcontainer": [
+    "y",
+    "n"
+  ],
+  "dockerfile": [
+    "y",
+    "n"
+  ],
+  "email": "fpgmaas@gmail.com",
+  "include_github_actions": [
+    "y",
+    "n"
+  ],
+  "layout": [
+    "flat",
+    "src"
+  ],
+  "mkdocs": [
+    "y",
+    "n"
+  ],
+  "open_source_license": [
+    "MIT license",
+    "BSD license",
+    "ISC license",
+    "Apache Software License 2.0",
+    "GNU General Public License v3",
+    "Not open source"
+  ],
+  "project_description": "This is a template repository for Python projects that use uv for their dependency management.",
+  "project_name": "example-project",
+  "project_slug": "{{cookiecutter.project_name|lower|replace('-', '_')}}",
+  "publish_to_pypi": [
+    "y",
+    "n"
+  ]
 }

--- a/docs/features/linting.md
+++ b/docs/features/linting.md
@@ -89,20 +89,6 @@ exclude = [
 
 [deptry](https://github.com/fpgmaas/deptry) is used to check the code for dependency issues, and it can be configured by adding a `[tool.deptry]` section in `pyproject.toml`. For more information, see [this section](https://deptry.com/usage/#configuration) documentation of deptry.
 
-# Prettier
-
-[Prettier](https://prettier.io/) is used to format the markdown documentation, along with any json and yaml files.
-Its options can be configured in the included `.editorconfig` file or in greater detail by adding a `.prettierrc` file ([See Docs](https://prettier.io/docs/en/configuration)).
-
-```yaml
-[*]
-max_line_length = 120
-
-[*.json]
-indent_style = space
-indent_size = 4
-```
-
 ## Github Actions
 
 If `include_github_actions` is set to `"y"`, code formatting is checked

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ This is a modern Cookiecutter template that can be used to initiate a Python pro
 - Supports both [src and flat layout](https://packaging.python.org/en/latest/discussions/src-layout-vs-flat-layout/).
 - CI/CD with [GitHub Actions](https://github.com/features/actions)
 - Pre-commit hooks with [pre-commit](https://pre-commit.com/)
-- Code quality with [ruff](https://github.com/charliermarsh/ruff), [mypy](https://mypy.readthedocs.io/en/stable/), [deptry](https://github.com/fpgmaas/deptry/) and [prettier](https://prettier.io/)
+- Code quality with [ruff](https://github.com/charliermarsh/ruff), [mypy](https://mypy.readthedocs.io/en/stable/) and [deptry](https://github.com/fpgmaas/deptry/).
 - Publishing to [PyPI](https://pypi.org) by creating a new release on GitHub
 - Testing and coverage with [pytest](https://docs.pytest.org/en/7.1.x/) and [codecov](https://about.codecov.io/)
 - Documentation with [MkDocs](https://www.mkdocs.org/)

--- a/{{cookiecutter.project_name}}/.editorconfig
+++ b/{{cookiecutter.project_name}}/.editorconfig
@@ -1,5 +1,0 @@
-max_line_length = 120
-
-[*.json]
-indent_style = space
-indent_size = 4

--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -10,6 +10,7 @@ repos:
         exclude: ^.devcontainer/devcontainer.json
       - id: pretty-format-json
         exclude: ^.devcontainer/devcontainer.json
+        args: [--autofix]
       - id: end-of-file-fixer
       - id: trailing-whitespace
 

--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -7,7 +7,9 @@ repos:
       - id: check-toml
       - id: check-yaml
       - id: check-json
+        exclude: ^.devcontainer/devcontainer.json
       - id: pretty-format-json
+        exclude: ^.devcontainer/devcontainer.json
       - id: end-of-file-fixer
       - id: trailing-whitespace
 

--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -1,11 +1,13 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: "v4.4.0"
+    rev: "v5.0.0"
     hooks:
       - id: check-case-conflict
       - id: check-merge-conflict
       - id: check-toml
       - id: check-yaml
+      - id: check-json
+      - id: pretty-format-json
       - id: end-of-file-fixer
       - id: trailing-whitespace
 
@@ -15,8 +17,3 @@ repos:
       - id: ruff
         args: [--exit-non-zero-on-fix]
       - id: ruff-format
-
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v3.0.3"
-    hooks:
-      - id: prettier


### PR DESCRIPTION
**PR Checklist**

- [ ] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated

**Description of changes**

The pre-commit hook of prettier is currently [archived](https://github.com/pre-commit/mirrors-prettier) and no longer maintained. See also [this issue](https://github.com/prettier/prettier/issues/15742#issuecomment-2136884297) for more background information.

This PR proposes to remove prettier, and instead add the following pre-commit-hooks:

- `check-json`
- `pretty-format-json`