### PR TITLE
ENH: Add deptry, mypy to pre-commit hooks, add pre-commit-update

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,3 +25,18 @@ repos:
       - id: ruff-format
         args: [--config=pyproject.toml]
         exclude: ^{{cookiecutter.project_name}}
+
+-   repo: https://github.com/python/mypy
+    rev: "v1.15.0"
+    hooks:
+    - id: mypy
+
+- repo: https://github.com/fpgmaas/deptry.git
+    rev: "0.23.0"
+    hooks:
+    - id: deptry
+
+- repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
+    rev: "v0.6.1"
+    hooks:
+    - id: pre-commit-update

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,17 +26,19 @@ repos:
         args: [--config=pyproject.toml]
         exclude: ^{{cookiecutter.project_name}}
 
--   repo: https://github.com/python/mypy
+  - repo: https://github.com/python/mypy
     rev: "v1.15.0"
     hooks:
     - id: mypy
+      exclude: ^{{cookiecutter.project_name}}
 
-- repo: https://github.com/fpgmaas/deptry.git
+  - repo: https://github.com/fpgmaas/deptry.git
     rev: "0.23.0"
     hooks:
     - id: deptry
+      exclude: ^{{cookiecutter.project_name}}
 
-- repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
+  - repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
     rev: "v0.6.1"
     hooks:
     - id: pre-commit-update

--- a/Makefile
+++ b/Makefile
@@ -43,10 +43,6 @@ check: ## Run code quality tools.
 	@uv lock --locked
 	@echo "🚀 Linting code: Running pre-commit"
 	@uv run pre-commit run -a
-	@echo "🚀 Static type checking: Running mypy"
-	@uv run mypy
-	@echo "🚀 Checking for obsolete dependencies: Running deptry"
-	@uv run deptry .
 
 .PHONY: test
 test: ## Test the code with pytest.


### PR DESCRIPTION
**PR Checklist**

- [ ] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated

**Description of changes**

Deptry and mypy are run in the Makefile in `make test` which makes it so that the lint unit test can fail. Would make sense to me to move those to the pre-commit. Also `pre-commit-update` is nice to keep the hooks up-to-date.
