### PR TITLE
Add Podman support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This is a modern Cookiecutter template that can be used to initiate a Python pro
 - Testing and coverage with [pytest](https://docs.pytest.org/en/7.1.x/) and [codecov](https://about.codecov.io/)
 - Documentation with [MkDocs](https://www.mkdocs.org/)
 - Compatibility testing for multiple versions of Python with [tox-uv](https://github.com/tox-dev/tox-uv)
-- Containerization with [Docker](https://www.docker.com/)
+- Containerization with [Docker](https://www.docker.com/) or [Podman](https://podman.io/)
 - Development environment with [VSCode devcontainers](https://code.visualstudio.com/docs/devcontainers/containers)
 
 ---

--- a/docs/features/docker.md
+++ b/docs/features/docker.md
@@ -1,23 +1,41 @@
-# Containerization with Docker
+# Containerization with Docker or Podman
 
 If `dockerfile` is set to `"y"`, a simple `Dockerfile` is added to the
-repository. The Dockerfile installs uv, sets up the environment and runs
-`foo.py` when run.
+repository. The Dockerfile installs uv, sets up the environment, and runs
+`foo.py` when executed.
 
-The docker image can be built with
-
-```bash
-docker build . -t my-docker-image
-```
-
-It can then be run in the background with
+The container image can be built with:
 
 ```bash
-docker run -d my-docker-image
+docker build . -t my-container-image
 ```
 
-Or, run it interactive mode with
+or, if using Podman:
 
+```bash
+podman build . -t my-container-image
 ```
-docker run --rm -it --entrypoint bash my-docker-image
+
+It can then be run in the background with:
+
+```bash
+docker run -d my-container-image
+```
+
+or, if using Podman:
+
+```bash
+podman run -d my-container-image
+```
+
+Alternatively, run it in interactive mode with:
+
+```bash
+docker run --rm -it --entrypoint bash my-container-image
+```
+
+or, if using Podman:
+
+```bash
+podman run --rm -it --entrypoint bash my-container-image
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ This is a modern Cookiecutter template that can be used to initiate a Python pro
 - Testing and coverage with [pytest](https://docs.pytest.org/en/7.1.x/) and [codecov](https://about.codecov.io/)
 - Documentation with [MkDocs](https://www.mkdocs.org/)
 - Compatibility testing for multiple versions of Python with [tox-uv](https://github.com/tox-dev/tox-uv)
-- Containerization with [Docker](https://www.docker.com/)
+- Containerization with [Docker](https://www.docker.com/) or [Podman](https://podman.io/)
 - Development environment with [VSCode devcontainers](https://code.visualstudio.com/docs/devcontainers/containers)
 
 An example of a repository generated with this package can be found [here](https://github.com/fpgmaas/cookiecutter-uv-example).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,7 +19,7 @@ nav:
       - Test coverage with codecov: features/codecov.md
       - Documentation with MkDocs: features/mkdocs.md
       - Compatibility testing with Tox: features/tox.md
-      - Containerization with Docker: features/docker.md
+      - Containerization with Docker or Podman: features/docker.md
       - Devcontainer with VSCode: features/devcontainer.md
   - Tutorial: tutorial.md
   - Prompt Arguments: prompt_arguments.md

--- a/{{cookiecutter.project_name}}/.devcontainer/devcontainer.json
+++ b/{{cookiecutter.project_name}}/.devcontainer/devcontainer.json
@@ -4,6 +4,10 @@
     "name": "{{cookiecutter.project_name}}",
     // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
     "image": "mcr.microsoft.com/devcontainers/python:1-3.11-bullseye",
+    "runArgs": [
+        // avoid UID/GID remapping under rootless Podman
+        "--userns=keep-id"
+      ],
     "features": {},
 
     // Use 'postCreateCommand' to run commands after the container is created.


### PR DESCRIPTION
**PR Checklist**

- [X] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [X] If you've fixed a bug or added code that should be tested, add tests!
- [x] Documentation in `docs` is updated

**Description of changes**

If podman is used to run the devcontainer, then an extra argument is needed to run the devcontainer under the local user id. Since this argument is specific to podman, it will not impact docker base devcontainers.

In the containerization documentation, the command examples for Podman have been added.