### PR TITLE
Update template files

### DIFF
--- a/{{cookiecutter.project_name}}/.github/actions/setup-python-env/action.yml
+++ b/{{cookiecutter.project_name}}/.github/actions/setup-python-env/action.yml
@@ -19,7 +19,7 @@ runs:
         python-version: {% raw %}${{ inputs.python-version }}{% endraw %}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v2
+      uses: astral-sh/setup-uv@v6
       with:
         version: {% raw %}${{ inputs.uv-version }}{% endraw %}
         enable-cache: 'true'

--- a/{{cookiecutter.project_name}}/.github/workflows/validate-codecov-config.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/validate-codecov-config.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   validate-codecov-config:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Validate codecov configuration

--- a/{{cookiecutter.project_name}}/.gitignore
+++ b/{{cookiecutter.project_name}}/.gitignore
@@ -4,7 +4,7 @@ docs/source
 
 # Byte-compiled / optimized / DLL files
 __pycache__/
-*.py[cod]
+*.py[codz]
 *$py.class
 
 # C extensions
@@ -50,7 +50,7 @@ htmlcov/
 nosetests.xml
 coverage.xml
 *.cover
-*.py,cover
+*.py.cover
 .hypothesis/
 .pytest_cache/
 cover/
@@ -86,6 +86,48 @@ target/
 profile_default/
 ipython_config.py
 
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+#poetry.toml
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#   pdm recommends including project-wide configuration in pdm.toml, but excluding .pdm-python.
+#   https://pdm-project.org/en/latest/usage/project/#working-with-version-control
+#pdm.lock
+#pdm.toml
+.pdm-python
+.pdm-build/
+
+# pixi
+#   Similar to Pipfile.lock, it is generally recommended to include pixi.lock in version control.
+#pixi.lock
+#   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one
+#   in the .venv directory. It is recommended not to include this directory in version control.
+.pixi
+
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
 __pypackages__/
 
@@ -98,6 +140,7 @@ celerybeat.pid
 
 # Environments
 .env
+.envrc
 .venv
 env/
 venv/
@@ -129,12 +172,40 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
-# Vscode config files
-.vscode/
-
 # PyCharm
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Abstra
+# Abstra is an AI-powered process automation framework.
+# Ignore directories containing user credentials, local state, and settings.
+# Learn more at https://abstra.io/docs
+.abstra/
+
+# Visual Studio Code
+#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore
+#  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
+#  and can be added to the global gitignore or merged into this file. However, if you prefer,
+#  you could uncomment the following to ignore the entire vscode folder
+# .vscode/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+# Cursor
+#  Cursor is an AI-powered code editor. `.cursorignore` specifies files/directories to
+#  exclude from AI features like autocomplete and code analysis. Recommended for sensitive data
+#  refer to https://docs.cursor.com/context/ignore-files
+.cursorignore
+.cursorindexingignore
+
+# Marimo
+marimo/_static/
+marimo/_lsp/
+__marimo__/


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated

**Description of changes**

- Update gitignore for Python from upstream (while keeping white space linting)
- Bump action astral-sh/setup-uv to latest v6 (to fix failing GitHub Actions CI)
  - https://github.com/astral-sh/setup-uv/releases/tag/v6.3.0
- Update ubuntu runner to latest (to keep it in-step with other jobs)

May also be worth updating runs-on declarations to track `ubuntu-latest`:

https://github.com/fpgmaas/cookiecutter-uv/blob/684961fc6f12824d0b4371a3bbf009501e6530af/%7B%7Bcookiecutter.project_name%7D%7D/.github/workflows/on-release-main.yml#L10

<details><summary>Example error from old setup-uv action</summary>

```
Run astral-sh/setup-uv@v2
  with:
    version: 0.6.14
    enable-cache: true
    github-token: ***
  env:
    pythonLocation: /opt/hostedtoolcache/Python/3.12.10/x64
    PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.12.10/x64/lib/pkgconfig
    Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.12.10/x64
    Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.12.10/x64
    Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.12.10/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.12.10/x64/lib
Downloading uv from "https://github.com/astral-sh/uv/releases/download/0.6.14/uv-x86_64-unknown-linux-gnu.tar.gz" ...
/usr/bin/tar xz --warning=no-unknown-keyword --overwrite -C /home/runner/work/_temp/d80fd1a7-1d52-4faa-aa11-63eaea444748 -f /home/runner/work/_temp/0330891b-ebba-4c6c-b2dd-746[27](https://github.com/.../.../actions/runs/.../job/...#step:4:31)ebccedc
Added /opt/hostedtoolcache/uv/0.6.14/x86_64 to the path
Successfully installed uv version 0.6.14
Set UV_CACHE_DIR to /home/runner/work/_temp/setup-uv-cache
Trying to restore uv cache from GitHub Actions cache with key: setup-uv-1-x86_64-unknown-linux-gnu-0.6.14-no-dependency-glob
Warning: Failed to restore: getCacheEntry failed: Cache service responded with 503
No GitHub Actions cache found for key: setup-uv-1-x86_64-unknown-linux-gnu-0.6.14-no-dependency-glob
Run uv sync --frozen
Using CPython 3.12.10 interpreter at: /opt/hostedtoolcache/Python/3.12.10/x64/bin/python3
Creating virtual environment at: .venv
error: Unable to find lockfile at `uv.lock`. To create a lockfile, run `uv lock` or `uv sync`.
Error: Process completed with exit code 2.
```

</details>