### PR TITLE
Fix: source uv env in devcontainer postCreateCommand.sh (#73)

### DIFF
--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -3,6 +3,10 @@
 # Install uv
 curl -LsSf https://astral.sh/uv/install.sh | sh
 
+# Make uv available in the current shell session
+# (the installer adds it to ~/.local/bin, which is not yet on PATH here)
+source "$HOME/.local/bin/env"
+
 # Install Dependencies
 uv sync
 

--- a/{{cookiecutter.project_name}}/.devcontainer/postCreateCommand.sh
+++ b/{{cookiecutter.project_name}}/.devcontainer/postCreateCommand.sh
@@ -3,6 +3,10 @@
 # Install uv
 curl -LsSf https://astral.sh/uv/install.sh | sh
 
+# Make uv available in the current shell session
+# (the installer adds it to ~/.local/bin, which is not yet on PATH here)
+source "$HOME/.local/bin/env"
+
 # Install Dependencies
 uv sync
 


### PR DESCRIPTION
## Summary

Fixes #73.

The devcontainer `postCreateCommand.sh` installs uv via `curl -LsSf https://astral.sh/uv/install.sh | sh`, but the subsequent `uv sync` fails with `uv: command not found` when the container is first created.

### Root cause

The uv installer places the binary in `~/.local/bin` and updates the shell profile, but those PATH changes only affect *new* shells. The `postCreateCommand.sh` keeps running in the same shell, so uv is not yet on `PATH` for the `uv sync` / `uv run` lines that follow.

(PR #74 added the `curl | sh` line, which is necessary but not sufficient — this is why #73 remained open.)

### Fix

Source the env file the installer creates, exactly as recommended by the installer's own output:

```bash
source "$HOME/.local/bin/env"
```

Applied to both:
- `.devcontainer/postCreateCommand.sh` (this repository's own devcontainer — the one reported in #73)
- `{{cookiecutter.project_name}}/.devcontainer/postCreateCommand.sh` (the generated project template, which had the identical bug)

### Verification

- Reproduced the failure in an isolated shell (clean `PATH`, custom install dir): `uv sync` step fails before the fix, succeeds after sourcing the env file.
- `tests/test_combinations.py`: 91/91 passed.
- Baked the template (`cookiecutter --no-input`) and confirmed the generated script renders correctly with `$HOME` preserved literally.