### PR TITLE
feat: initialize a git repository in generated projects (#59)

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -3,8 +3,31 @@ from __future__ import annotations
 
 import os
 import shutil
+import subprocess
 
 PROJECT_DIRECTORY = os.path.realpath(os.path.curdir)
+
+
+def git_init() -> None:
+    """Initialize a git repository in the generated project.
+
+    Mirrors the behaviour of ``uv init``. Failures (git not installed, or the
+    directory already being inside a repository) are non-fatal so that project
+    generation always succeeds.
+    """
+    if os.path.isdir(os.path.join(PROJECT_DIRECTORY, ".git")):
+        return
+    try:
+        subprocess.run(
+            ["git", "init"],
+            cwd=PROJECT_DIRECTORY,
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        # git is unavailable or failed; skip silently rather than failing generation.
+        pass
 
 
 def remove_file(filepath: str) -> None:
@@ -96,3 +119,5 @@ if __name__ == "__main__":
         if os.path.isdir("src"):
             remove_dir("src")
         move_dir("{{cookiecutter.project_slug}}", os.path.join("src", "{{cookiecutter.project_slug}}"))
+
+    git_init()

--- a/tests/test_combinations.py
+++ b/tests/test_combinations.py
@@ -111,6 +111,10 @@ class TestStructure:
             assert project.has_dir("example_project")
             assert not project.has_dir("src")
 
+    def test_git_initialized(self, bake, options):
+        project = bake(**options)
+        assert project.has_dir(".git"), "Expected the generated project to be a git repository"
+
     def test_release_workflow(self, bake, options):
         effective = resolve_options(options)
         project = bake(**options)


### PR DESCRIPTION
## Summary

Fixes #59.

Currently a freshly generated project is **not** a git repository — the user has to run `git init` manually before they can install pre-commit hooks or make a first commit. `uv init` initializes a repo by default, and this template aims to offer the same experience plus extras.

### Change

`hooks/post_gen_project.py` now runs `git init` in the generated project directory as the final post-generation step.

It is intentionally defensive:
- skipped if the directory is already a git repository (`.git` exists);
- any failure (e.g. git not installed, or a sandboxed environment) is caught and ignored, so project generation never fails because of it.

### Verification

- Added `test_git_initialized` to `tests/test_combinations.py`, asserting the baked project contains a `.git` directory across all option combinations.
- Full non-slow combinations suite passes.