### PR TITLE
feat: expose package version as __version__ (#100)

### DIFF
--- a/tests/test_combinations.py
+++ b/tests/test_combinations.py
@@ -111,6 +111,14 @@ class TestStructure:
             assert project.has_dir("example_project")
             assert not project.has_dir("src")
 
+    def test_version_in_init(self, bake, options):
+        effective = resolve_options(options)
+        project = bake(**options)
+        package_dir = "src/example_project" if effective["layout"] == "src" else "example_project"
+        init = project.read_file(f"{package_dir}/__init__.py")
+        assert "__version__" in init
+        assert 'version("example-project")' in init
+
     def test_release_workflow(self, bake, options):
         effective = resolve_options(options)
         project = bake(**options)

--- a/{{cookiecutter.project_name}}/{{cookiecutter.project_slug}}/__init__.py
+++ b/{{cookiecutter.project_name}}/{{cookiecutter.project_slug}}/__init__.py
@@ -1,0 +1,8 @@
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("{{cookiecutter.project_name}}")
+except PackageNotFoundError:  # pragma: no cover
+    # Package is not installed (e.g. running from a source checkout
+    # without an editable install).
+    __version__ = "0.0.0"


### PR DESCRIPTION
## Summary

Fixes #100.

It is common to want to access or log a package's version at runtime. This populates the generated package's `__init__.py` with a `__version__` attribute:

```python
from importlib.metadata import PackageNotFoundError, version

try:
    __version__ = version("example-project")
except PackageNotFoundError:  # pragma: no cover
    __version__ = "0.0.0"
```

The version is read from the installed distribution metadata via `importlib.metadata`, so it stays in sync with `pyproject.toml` without parsing files. As noted in the issue, with `uv` the metadata is reliably updated, so this avoids the staleness problems seen with some other workflows.

The `PackageNotFoundError` fallback keeps imports working when the package is not installed (e.g. running straight from a source checkout without an editable install).

### Verification

- Added `test_version_in_init` to `tests/test_combinations.py` (covers both flat and src layouts).
- `test_check_passes_on_default_project` passes, so the new `__init__.py` clears the generated project's own ruff/mypy/deptry checks.
- Verified end-to-end: after `uv sync`, `import example_project; example_project.__version__` returns `0.0.1`.