### PR TITLE
feat: add Dependabot config for automated dependency updates (#80)

### DIFF
--- a/tests/test_combinations.py
+++ b/tests/test_combinations.py
@@ -111,6 +111,15 @@ class TestStructure:
             assert project.has_dir("example_project")
             assert not project.has_dir("src")
 
+    def test_dependabot(self, bake, options):
+        effective = resolve_options(options)
+        project = bake(**options)
+        if effective["include_github_actions"] == "y":
+            assert project.has_file(".github/dependabot.yml")
+            assert project.is_valid_yaml(".github/dependabot.yml")
+        else:
+            assert not project.has_file(".github/dependabot.yml")
+
     def test_release_workflow(self, bake, options):
         effective = resolve_options(options)
         project = bake(**options)

--- a/{{cookiecutter.project_name}}/.github/dependabot.yml
+++ b/{{cookiecutter.project_name}}/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  # Keep Python dependencies (managed by uv) up to date.
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  # Keep GitHub Actions up to date.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary

Fixes #80.

Adds a `.github/dependabot.yml` to generated projects so dependencies are kept up to date automatically. It configures two ecosystems on a weekly schedule:

- **`uv`** — the project's Python dependencies (Dependabot has native uv support);
- **`github-actions`** — the workflows shipped by the template.

```yaml
version: 2
updates:
  - package-ecosystem: "uv"
    directory: "/"
    schedule:
      interval: "weekly"
    open-pull-requests-limit: 10
  - package-ecosystem: "github-actions"
    directory: "/"
    schedule:
      interval: "weekly"
    open-pull-requests-limit: 10
```

I went with Dependabot over Renovate since it's native to GitHub and needs no extra app installation. The file lives under `.github/`, so it is only emitted when GitHub Actions support is enabled and is removed together with `.github` otherwise — no new post-generation logic required.

### Verification

- Added `test_dependabot` to `tests/test_combinations.py`: asserts the file is present and valid YAML when `include_github_actions == "y"`, and absent otherwise.
- Full non-slow combinations suite passes.